### PR TITLE
disabled parsing for html grammar

### DIFF
--- a/_grammar-test/src/test/java/TestHtml.java
+++ b/_grammar-test/src/test/java/TestHtml.java
@@ -1,11 +1,8 @@
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.snt.inmemantlr.GenericParser;
 import org.snt.inmemantlr.exceptions.CompilationException;
-import org.snt.inmemantlr.exceptions.IllegalWorkflowException;
-import org.snt.inmemantlr.exceptions.ParsingException;
 import org.snt.inmemantlr.listener.DefaultTreeListener;
 
 import java.io.File;
@@ -26,6 +23,7 @@ public class TestHtml {
 
     @Test
     public void test() {
+
 
         GenericParser gp = null;
         try {
@@ -48,16 +46,16 @@ public class TestHtml {
 
         assertTrue(compile);
 
-        for (File f : ok) {
-            LOGGER.info("parse {}", f.getAbsoluteFile());
-            try {
-                gp.parse(f,"htmlDocument", GenericParser.CaseSensitiveType.NONE);
-            } catch (IllegalWorkflowException |
-                    FileNotFoundException |
-                    ParsingException e) {
-                Assert.assertTrue(false);
-            }
-        }
+//        for (File f : ok) {
+//            LOGGER.info("parse {}", f.getAbsoluteFile());
+//            try {
+//                gp.parse(f,"htmlDocument", GenericParser.CaseSensitiveType.NONE);
+//            } catch (IllegalWorkflowException |
+//                    FileNotFoundException |
+//                    ParsingException e) {
+//                Assert.assertTrue(false);
+//            }
+//        }
     }
 
 


### PR DESCRIPTION
I disabled the file parsing tests for the html test case to be in sync with the maven-test-plugin test case (https://github.com/antlr/grammars-v4/blob/master/html/pom.xml). I suppose the test case is disabled because the parsing of the HTML files takes really long.